### PR TITLE
Cratis 8 api config system

### DIFF
--- a/cratis-cli/src/cli.rs
+++ b/cratis-cli/src/cli.rs
@@ -130,7 +130,7 @@ pub async fn ping_server() -> CratisResult<String> {
 }
 
 pub async fn backup_now() -> CratisResult<String> {
-    let config = cratis_core::config::get_config();
+    let config = cratis_core::config::get_config_cli();
     let watch_dirs = &config.backup.watch_directories;
 
     let mut files_to_load: Vec<PathBuf> = Vec::new();

--- a/cratis-cli/src/main.rs
+++ b/cratis-cli/src/main.rs
@@ -8,7 +8,7 @@ mod cli;
 
 #[tokio::main]
 async fn main() {
-    load_config(TEMP_CONFIG_PATH);
+    load_config(TEMP_CONFIG_PATH, false);
     let cli_ = cli::Cli::parse();
 
     match cli_.command {
@@ -18,7 +18,7 @@ async fn main() {
             match register().await {
                 Ok(token) => {
                     display_msg(None, CratisErrorLevel::Info, Some("Registered successfully!".to_string()));
-                    match update_config("server.auth_token", Value::String(token)) {
+                    match update_config("server.auth_token", TEMP_CONFIG_PATH, Value::String(token)) {
                         Ok(_) => display_msg(None, CratisErrorLevel::Info, Some("Updated config successfully!".to_string())),
                         Err(e) => display_msg(Some(&e), CratisErrorLevel::Warning, None),
                     }

--- a/cratis-core/src/config.rs
+++ b/cratis-core/src/config.rs
@@ -87,6 +87,14 @@ pub fn load_config(path: &str, api: bool) {
 }
 
 
+/// Returns a reference to the global CLI configuration.
+///
+/// Lazily loads the configuration from the default path if not already loaded.
+/// Terminates the program if configuration loading fails.
+///
+/// # Returns
+///
+/// A static reference to the loaded `CratisConfig`
 pub fn get_config_cli() -> &'static CratisConfig {
     if CONFIG_CLI.get().is_none() {
         load_config(TEMP_CONFIG_PATH, false);
@@ -102,6 +110,14 @@ pub fn get_config_cli() -> &'static CratisConfig {
     }
 }
 
+/// Returns a reference to the global API server configuration.
+///
+/// Lazily loads the configuration from the default path if not already loaded.
+/// Terminates the program if configuration loading fails.
+///
+/// # Returns
+///
+/// A static reference to the loaded `CratisServerConfig`
 pub fn get_config_api() -> &'static CratisServerConfig {
     if CONFIG_API.get().is_none() {
         load_config(TEMP_API_CONFIG_PATH, true);

--- a/cratis-core/src/config.rs
+++ b/cratis-core/src/config.rs
@@ -54,9 +54,14 @@ pub struct AdvancedConfig {
 
 #[derive(Debug, Deserialize)]
 pub struct CratisServerConfig {
+    pub settings: CratisServerSettings,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CratisServerSettings {
     pub port: u16,
-    pub env: String,
     pub db: String,
+    pub jwt: String,
 }
 
 static CONFIG_CLI: OnceCell<CratisConfig> = OnceCell::new();

--- a/cratis-core/src/error.rs
+++ b/cratis-core/src/error.rs
@@ -61,26 +61,26 @@ pub enum CratisErrorLevel {
 
 pub type CratisResult<T> = Result<T, CratisError>;
 
-/// Displays a Cratis error message to standard error (stderr).
+/// Displays a Cratis message to standard error (stderr).
 ///
 /// # Arguments
 ///
-/// * `error` - A reference to the CratisError to be displayed
-/// * `debug` - A boolean flag that determines the error output format
+/// * `error` - Optional reference to a CratisError to be displayed (used for Warning/Fatal).
+/// * `level` - Info, Warning, or Fatal.
+/// * `msg` - Optional message string for Info messages.
 ///
-/// When `debug` is true, displays the error using pretty-printed debug formatting ({:#?}).
-/// When `debug` is false, displays a simple user-friendly error message using the Display trait.
+/// Behavior:
+/// - Info: prints "Info: {msg}"
+/// - Warning: prints "Warning: {error}"
+/// - Fatal: prints "Fatal error: {error}" and exits with code 1.
 ///
 /// # Examples
-///
 /// ```ignore
-/// use cratis_core::CratisError;
+/// use cratis_core::error::{display_msg, CratisError, CratisErrorLevel};
 ///
-/// let error = CratisError::InvalidInput("Invalid configuration");
-/// display_msg(&error, false); // Displays: "Invalid input provided: Invalid configuration"
-/// display_msg(&error, true);  // Displays detailed debug structure with formatting
+/// display_msg(None, CratisErrorLevel::Info, Some("Starting backup".into()));
+/// display_msg(Some(&CratisError::InvalidInput("Invalid configuration")), CratisErrorLevel::Warning, None);
 /// ```
-///
 pub fn display_msg(error: Option<&CratisError>, level: CratisErrorLevel, msg: Option<String> /* msg is for info messages only */) {
     let error = error.unwrap_or(&CratisError::Unknown);
     let msg = msg.unwrap_or("".to_string());

--- a/cratis-core/src/error.rs
+++ b/cratis-core/src/error.rs
@@ -39,7 +39,7 @@ pub enum CratisError {
     #[error("Database error: {0}")]
     DatabaseError(String),
 
-    #[error("Error generating token: {0}")] 
+    #[error("Error generating token: {0}")]
     TokenError(String),
 
     #[error("Environment error: {0}")]
@@ -86,11 +86,11 @@ pub fn display_msg(error: Option<&CratisError>, level: CratisErrorLevel, msg: Op
     let msg = msg.unwrap_or("".to_string());
 
     if level == CratisErrorLevel::Info {
-        eprintln!("Info: \n{msg}");
+        eprintln!("Info: {msg}");
     } else if level == CratisErrorLevel::Warning {
-        eprintln!("Warning: \n{error}");
+        eprintln!("Warning: {error}");
     } else if level == CratisErrorLevel::Fatal {
-        eprintln!("Fatal error: \n{error}");
+        eprintln!("Fatal error: {error}");
         std::process::exit(1);
     }
 }

--- a/cratis-core/src/utils.rs
+++ b/cratis-core/src/utils.rs
@@ -278,7 +278,7 @@ pub fn get_files_in_directory(dir: &String) -> CratisResult<Vec<PathBuf>> {
         return Err(CratisError::InvalidPath(format!("The path does not exist: {}", dir)));
     }
 
-    let config: &CratisConfig = crate::config::get_config();
+    let config: &CratisConfig = crate::config::get_config_cli();
 
     let exclude_dirs: &Vec<String> = &config.backup.exclude.clone().unwrap_or_default();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Config-driven API startup: server port, database path and JWT are now read from the API config file.
  - Added public endpoints: /register and /ping.

- Refactor
  - Separated CLI and server configurations; CLI tools use the CLI config, server uses the API config.
  - Replaced .env startup with explicit config loading for CLI and API.
  - Startup now warns when JWT is empty and shows clearer log/error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->