### PR TITLE
Removed the storing of the jwt in database

### DIFF
--- a/cratis-api/src/handler/authentication.rs
+++ b/cratis-api/src/handler/authentication.rs
@@ -25,7 +25,6 @@ pub struct RegisterRequestData {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Device {
     device_id: String,
-    auth_token: String,
 }
 
 // JWT Struct
@@ -96,8 +95,8 @@ pub async fn register(Json(payload): Json<RegisterRequestData>) -> impl IntoResp
         None => return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "error": "Internal Server Error" })))
     };
 
-    // Insert device_id and jwt into db
-    let result = collection.insert_one(Device {device_id, auth_token: jwt.clone()});
+    // Store device_id in db
+    let result = collection.insert_one(Device {device_id});
     if let Err(e) = result {
         display_msg(Some(&CratisError::DatabaseError(format!("Error inserting data: {}", e))), CratisErrorLevel::Warning, None);
         return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "error": "Internal Server Error" })))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined device records to store only the device ID; authentication tokens are no longer persisted.
* **Chores**
  * Updated registration flow to continue issuing tokens to clients without saving them.
  * Refreshed internal comments to reflect the new storage behavior.

Impact:
- Reduced stored sensitive data while preserving existing sign-in behavior.
- No action required for users; token retrieval remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->